### PR TITLE
Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:0.10-slim
+
+RUN apt-get update \
+    && apt-get install git ca-certificates -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists* \
+    && git clone https://github.com/xemle/spop-web.git /spop-web \
+    && cd /spop-web \
+    && npm install -g bower gulp-cli \
+    && npm install \
+    && bower --allow-root install \
+    && gulp \
+    && apt-get purge -y --auto-remove git ca-certificates
+
+WORKDIR /spop-web
+EXPOSE 3000
+CMD ["node", "index.js"]

--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ spop web uses:
 
 Open your browser at [localhost:3000](http://localhost:3000)
 
+## With Docker
+
+If you don't want to install Node / Bower / Gulp on your local machine, you can
+do all of that in a Docker container:
+
+    $ docker build -t spop-web .
+    $ docker run -ti -p 3000:3000 --net=host --rm spop-web
+
+Then open your browser at [localhost:3000](http://localhost:3000).
+
 ## Contribute
 
 Contributions are welcome. To do so, please:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ like HiFi Berry.
     $ npm install -g bower gulp-cli
     $ npm install
     $ bower install
+    $ gulp
 
 spop web uses:
 


### PR DESCRIPTION
This adds a Dockerfile for spop-web. Useful for people like me who don't want to globally install Bower / Gulp / other Node tools.
This can be used to trigger an automated build on the Docker Hub (https://registry.hub.docker.com/u/schnouki/spop-web/).
